### PR TITLE
Fix favorites not being centered when apps are disabled

### DIFF
--- a/newtab.html
+++ b/newtab.html
@@ -19,7 +19,7 @@
 
 <body style="background: #222222;">
   <div class="container">
-    <div id="apps" style="height:147px;"></div>
+    <div id="apps"></div>
     <div class="favorites" id="links" style="min-height: 283px;">
       <div class="favorites-list" id="topsites-list">
         <ul id="topsites">


### PR DESCRIPTION
Otherwise the apps div forces the favorites div down making it off-centered when the apps div is empty. This still works fine when apps are enabled, the apps div has a height of 147px without needing to explicitly set it.