### PR TITLE
Hide search results when search box is empty

### DIFF
--- a/search.js
+++ b/search.js
@@ -86,6 +86,13 @@ var searchCallback = function(list) {
 			script.outerHTML = "";
 			script.delete;
 		}
+
+		if (val.length == 0) {
+			document.getElementById("callback").style.visibility = "hidden";
+		}
+		else {
+			document.getElementById("callback").style.visibility = "visible";
+		}
 	}
 
 	if (list["search"] == "duckduckgo") {


### PR DESCRIPTION
When the search box is backspaced, the previous search results are now hidden.