### PR TITLE
Fix URL parsing in the search box to avoid erroneous site navigation

### DIFF
--- a/search.js
+++ b/search.js
@@ -108,11 +108,16 @@ var searchCallback = function(list) {
 		var value = searchbox.value;
 		e.preventDefault();
 		var value = searchbox.value;
-		if (value.indexOf(".") >= 0) {
-			window.location = addhttp(value);;
+		var url = asUrl(value);
+		if (url != null) {
+			window.location = url;
 		} else {
 			form.submit();
 		}
 	}, false);
 }
 
+function asUrl(str) {
+	// If the url is valid (with or without http/s), add http:// if missing and return - otherwise return null
+	return (/^(?:(http|https):\/\/)?(?:[\w-]+\.)+[a-z]{2,24}(\/[\w-]*)*$/i.test(str)) ? addhttp(str) : null;
+}

--- a/search.js
+++ b/search.js
@@ -119,5 +119,5 @@ var searchCallback = function(list) {
 
 function asUrl(str) {
 	// If the url is valid (with or without http/s), add http:// if missing and return - otherwise return null
-	return (/^(?:(http|https):\/\/)?(?:[\w-]+\.)+[a-z]{2,24}(\/[\w-]*)*$/i.test(str)) ? addhttp(str) : null;
+	return (/^(?:(http|https):\/\/)?(?:[\w-]+\.)+[a-z]{2,24}(\/[\w-]*)*(\.[\w-]+)?$/i.test(str)) ? addhttp(str) : null;
 }


### PR DESCRIPTION
This PR fixes the extension's URL parsing (previously tested if any period was present) to a more comprehensive regex string checking optional protocol, domain characters, TLD length, and optionally the page directory and file extension.

This fixes a recurring issue with the extension attempting to navigate to strings misrecognized as URLs (such as decimal numbers, etc--anything with a `.` character).